### PR TITLE
Add build.rs to build pri.c on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [
   "benches/*",
   "test.jpg"
 ]
+build = "build.rs"
 
 [dependencies]
 glium = "0.18.0"
@@ -22,6 +23,9 @@ gl = "0.6.3"
 nalgebra = "0.13.1"
 image = "0.17.0"
 owning_ref = "0.3.3"
+
+[build-dependencies]
+cc = "1.0"
 
 [features]
 default = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+extern crate cc;
+
+fn main() {
+    if cfg!(target_os = "macos") {
+        cc::Build::new()
+            .file("pri.c")
+            .compile("pri");
+    }
+}


### PR DESCRIPTION
I special-cased the building to only be done on macOS as pri is only linked on macOS currently.